### PR TITLE
Seperate and change strategy to simplify the deployment of the esgf-pub env

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -41,3 +41,12 @@
             name: data
       tags: data
       when: "'data' in group_names"
+
+    - name: Publisher
+      block:
+        - include_role:
+            name: publisher
+      tags:
+        - data
+        - publisher
+      when: "'data' in group_names"

--- a/roles/data/tasks/globus.yml
+++ b/roles/data/tasks/globus.yml
@@ -135,22 +135,3 @@
     remote_src: yes
     src: /etc/resolv.conf
     dest: "{{ gridftp.chroot }}/etc/resolv.conf"
-
-- name: Retrieve info about what datasets to mount
-  fetch:
-    src: "{{ esg.config.dir }}/esgcet/esg.ini"
-    dest: /tmp/
-    flat: yes
-
-- name: Read datasets from esg.ini
-  set_fact:
-    raw_dataset_roots: "{{ lookup('ini', 'thredds_dataset_roots section=DEFAULT file=/tmp/esg.ini') }}"
-
-- name: Mount the dataset root directories into the chroot GridFTP
-  mount:
-    path: "{{ gridftp.chroot }}/{{ item.split('|')[0].strip() }}"
-    src: "{{ item.split('|')[1].strip() }}"
-    opts: rw,bind
-    fstype: gpfs
-    state: mounted
-  with_items: "{{ raw_dataset_roots.split('\n')[1:] }}"

--- a/roles/data/tasks/main.yml
+++ b/roles/data/tasks/main.yml
@@ -5,9 +5,6 @@
 - name: Import postgres tasks
   import_tasks: postgres.yml
 
-- name: Import publisher tasks
-  import_tasks: publisher.yml
-
 - name: Import globus tasks
   import_tasks: globus.yml
 

--- a/roles/data/tasks/thredds.yml
+++ b/roles/data/tasks/thredds.yml
@@ -124,16 +124,3 @@
     owner: tomcat
     group: tomcat
     recurse: yes
-
-# Configure publisher with thredds
-- name: Run esgsetup for thredds
-  no_log: true
-  shell: >
-    {{ conda.actv }} esgf-pub && \
-    esgsetup --config --minimal-setup \
-    --thredds --publish --gateway {{ groups['index'][0] }} \
-    --thredds-password {{ admin_pass }}
-  # args:
-  #   creates: /esg/config/esgcet/*
-  environment:
-    UVCDAT_ANONYMOUS_LOG: no

--- a/roles/publisher/files/environment.yml
+++ b/roles/publisher/files/environment.yml
@@ -1,0 +1,7 @@
+name: esgf-pub
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - 'python<3'
+  - 'cmor==3.4.0'

--- a/roles/publisher/tasks/main.yml
+++ b/roles/publisher/tasks/main.yml
@@ -8,39 +8,25 @@
       - libxslt-devel
       - gcc
 
-- name: Check for correct esgf-publisher
+# Create a simple environment for esgsetup only
+- name: Check for esgsetup-env
   stat:
-    path: "{{ conda.envs }}/esgf-pub/{{ conda.mods }}/esgcet-{{ publisher.pip.version }}.dist-info"
-  register: publisher_module
+    path: "{{ conda.envs }}/esgsetup-env"
+  register: esgsetup_result
 
-- name: Cleanup publisher repo
-  when: not publisher_module.stat.exists
-  command: "{{ conda.exe }} env remove -y -n esgf-pub"
-  register: remove_esgfpub
-  failed_when: remove_esgfpub.rc != 0 and "Not a conda environment" not in remove_esgfpub.stderr
+- name: Create esgsetup-env if it does not exist
+  when: not esgsetup_result.stat.exists
+  command: "{{ conda.exe }} create -y -n esgsetup_env 'python<3'"
 
-- name: Create esgf-pub conda env
-  when: not publisher_module.stat.exists
-  command: "{{ conda.exe }} create -y -n esgf-pub 'python<3' pip"
-  args:
-    creates: "{{ conda.envs }}/esgf-pub"
-
-- name: Install CMOR into esgf-pub
-  command: "{{ conda.exe }} install -y -n esgf-pub cmor -c conda-forge"
-
-# The requests install in the below statement is to match the requests in esgprep
-- name: Install publisher
-  when: not publisher_module.stat.exists
+- name: Install publisher for esgsetup
   shell: >
-    {{ conda.actv }} esgf-pub && \
+    {{ conda.actv }} esgsetup-env && \
     pip install '{{ publisher.pip.name }}' 'requests==2.20.0'
-  args:
-    creates: "{{ conda.envs }}/esgf-pub/{{ conda.mods }}/esgcet-{{ publisher.pip.version }}.dist-info"
-  register: pub_pip
 
+# Perform esgsetup steps
 - name: Run esgsetup for config files
   shell: >
-    {{ conda.actv }} esgf-pub && \
+    {{ conda.actv }} esgsetup-env && \
     esgsetup --config --minimal-setup --rootid {{ ansible_fqdn.split('.', 1)[-1] }}
   args:
     creates: "{{ esg.config.dir }}/esgcet/esg.ini"
@@ -63,7 +49,7 @@
 - name: Run esgsetup for the database
   no_log: true
   shell: >
-    {{ conda.actv }} esgf-pub && \
+    {{ conda.actv }} esgsetup-env && \
     esgsetup --db --minimal-setup \
     --db-name {{ all_db.db }} \
     --db-admin {{ all_db.users.super.name }} \
@@ -72,17 +58,13 @@
     --db-user-password {{ data_db.users.pub.pass }} \
     --db-host {{ all_db.host }} \
     --db-port {{ all_db.port }}
-#   args:
-#     creates: /esg/config/esgcet/*
   environment:
     UVCDAT_ANONYMOUS_LOG: no
 
 - name: Run esginitialize
   shell: >
-    {{ conda.actv }} esgf-pub && \
+    {{ conda.actv }} esgsetup-env && \
     esginitialize -c
-#   args:
-#     creates: /esg/config/esgcet/*
   environment:
     UVCDAT_ANONYMOUS_LOG: no
 
@@ -95,12 +77,10 @@
 - name: Run esgsetup for thredds
   no_log: true
   shell: >
-    {{ conda.actv }} esgf-pub && \
+    {{ conda.actv }} esgsetup-env && \
     esgsetup --config --minimal-setup \
     --thredds --publish --gateway {{ groups['index'][0] }} \
     --thredds-password {{ admin_pass }}
-  # args:
-  #   creates: /esg/config/esgcet/*
   environment:
     UVCDAT_ANONYMOUS_LOG: no
 
@@ -122,3 +102,30 @@
     fstype: gpfs
     state: mounted
   with_items: "{{ raw_dataset_roots.split('\n')[1:] }}"
+
+
+# Create actual publishing environment
+- name: Check for correct esgf-publisher
+  stat:
+    path: "{{ conda.envs }}/esgf-pub/{{ conda.mods }}/esgcet-{{ publisher.pip.version }}.dist-info"
+  register: publisher_module
+
+- name: Cleanup publisher repo
+  when: not publisher_module.stat.exists
+  command: "{{ conda.exe }} env remove -y -n esgf-pub"
+  register: remove_esgfpub
+  failed_when: remove_esgfpub.rc != 0 and "Not a conda environment" not in remove_esgfpub.stderr
+
+- name: Create esgf-pub conda env
+  when: not publisher_module.stat.exists
+  command: "{{ conda.exe }} create -y -n esgf-pub 'python<3'"
+
+- name: Install CMOR into esgf-pub
+  when: not publisher_module.stat.exists
+  command: "{{ conda.exe }} install -y -n esgf-pub 'cmor==3.4.0' -c conda-forge"
+
+- name: Install publisher
+  when: not publisher_module.stat.exists
+  shell: >
+    {{ conda.actv }} esgf-pub && \
+    pip install '{{ publisher.pip.name }}' 'requests==2.20.0'

--- a/roles/publisher/tasks/main.yml
+++ b/roles/publisher/tasks/main.yml
@@ -15,15 +15,18 @@
 
 - name: Cleanup publisher repo
   when: not publisher_module.stat.exists
-  file:
-    path: "{{ conda.envs }}/esgf-pub"
-    state: absent
+  command: "{{ conda.exe }} env remove -y -n esgf-pub"
+  register: remove_esgfpub
+  failed_when: remove_esgfpub.rc != 0 and "Not a conda environment" not in remove_esgfpub.stderr
 
 - name: Create esgf-pub conda env
   when: not publisher_module.stat.exists
-  command: "{{ conda.exe }} create -y -n esgf-pub 'python<3' pip cmor -c conda-forge"
+  command: "{{ conda.exe }} create -y -n esgf-pub 'python<3' pip"
   args:
     creates: "{{ conda.envs }}/esgf-pub"
+
+- name: Install CMOR into esgf-pub
+  command: "{{ conda.exe }} install -y -n esgf-pub cmor -c conda-forge"
 
 # The requests install in the below statement is to match the requests in esgprep
 - name: Install publisher
@@ -87,3 +90,35 @@
   file:
     path: /esg/data/test
     state: directory
+
+# Configure publisher with thredds
+- name: Run esgsetup for thredds
+  no_log: true
+  shell: >
+    {{ conda.actv }} esgf-pub && \
+    esgsetup --config --minimal-setup \
+    --thredds --publish --gateway {{ groups['index'][0] }} \
+    --thredds-password {{ admin_pass }}
+  # args:
+  #   creates: /esg/config/esgcet/*
+  environment:
+    UVCDAT_ANONYMOUS_LOG: no
+
+- name: Retrieve info about what datasets to mount
+  fetch:
+    src: "{{ esg.config.dir }}/esgcet/esg.ini"
+    dest: /tmp/
+    flat: yes
+
+- name: Read datasets from esg.ini
+  set_fact:
+    raw_dataset_roots: "{{ lookup('ini', 'thredds_dataset_roots section=DEFAULT file=/tmp/esg.ini') }}"
+
+- name: Mount the dataset root directories into the chroot GridFTP
+  mount:
+    path: "{{ gridftp.chroot }}/{{ item.split('|')[0].strip() }}"
+    src: "{{ item.split('|')[1].strip() }}"
+    opts: rw,bind
+    fstype: gpfs
+    state: mounted
+  with_items: "{{ raw_dataset_roots.split('\n')[1:] }}"

--- a/roles/publisher/tasks/main.yml
+++ b/roles/publisher/tasks/main.yml
@@ -8,15 +8,13 @@
       - libxslt-devel
       - gcc
 
-# Create a simple environment for esgsetup only
-- name: Check for esgf-pub
-  stat:
-    path: "{{ conda.envs }}/esgf-pub"
-  register: esgf_pub_result
+- name: Install environment.yml file
+  copy:
+    src: environment.yml
+    dest: /tmp/esgf-pub.yml
 
 - name: Create esgf-pub if it does not exist
-  when: not esgf_pub_result.stat.exists
-  command: "{{ conda.exe }} create -y -n esgf-pub 'python<3' 'cmor==3.4.0' -c defaults -c conda-forge"
+  command: "{{ conda.exe }} env update -n esgf-pub -f=/tmp/esgf-pub.yml"
 
 - name: Install publisher for esgsetup
   shell: >

--- a/roles/publisher/tasks/main.yml
+++ b/roles/publisher/tasks/main.yml
@@ -9,24 +9,24 @@
       - gcc
 
 # Create a simple environment for esgsetup only
-- name: Check for esgsetup-env
+- name: Check for esgf-pub
   stat:
-    path: "{{ conda.envs }}/esgsetup-env"
-  register: esgsetup_result
+    path: "{{ conda.envs }}/esgf-pub"
+  register: esgf_pub_result
 
-- name: Create esgsetup-env if it does not exist
-  when: not esgsetup_result.stat.exists
-  command: "{{ conda.exe }} create -y -n esgsetup_env 'python<3'"
+- name: Create esgf-pub if it does not exist
+  when: not esgf_pub_result.stat.exists
+  command: "{{ conda.exe }} create -y -n esgf-pub 'python<3' 'cmor==3.4.0' -c defaults -c conda-forge"
 
 - name: Install publisher for esgsetup
   shell: >
-    {{ conda.actv }} esgsetup-env && \
+    {{ conda.actv }} esgf-pub && \
     pip install '{{ publisher.pip.name }}' 'requests==2.20.0'
 
 # Perform esgsetup steps
 - name: Run esgsetup for config files
   shell: >
-    {{ conda.actv }} esgsetup-env && \
+    {{ conda.actv }} esgf-pub && \
     esgsetup --config --minimal-setup --rootid {{ ansible_fqdn.split('.', 1)[-1] }}
   args:
     creates: "{{ esg.config.dir }}/esgcet/esg.ini"
@@ -49,7 +49,7 @@
 - name: Run esgsetup for the database
   no_log: true
   shell: >
-    {{ conda.actv }} esgsetup-env && \
+    {{ conda.actv }} esgf-pub && \
     esgsetup --db --minimal-setup \
     --db-name {{ all_db.db }} \
     --db-admin {{ all_db.users.super.name }} \
@@ -63,7 +63,7 @@
 
 - name: Run esginitialize
   shell: >
-    {{ conda.actv }} esgsetup-env && \
+    {{ conda.actv }} esgf-pub && \
     esginitialize -c
   environment:
     UVCDAT_ANONYMOUS_LOG: no
@@ -77,7 +77,7 @@
 - name: Run esgsetup for thredds
   no_log: true
   shell: >
-    {{ conda.actv }} esgsetup-env && \
+    {{ conda.actv }} esgf-pub && \
     esgsetup --config --minimal-setup \
     --thredds --publish --gateway {{ groups['index'][0] }} \
     --thredds-password {{ admin_pass }}
@@ -102,30 +102,3 @@
     fstype: gpfs
     state: mounted
   with_items: "{{ raw_dataset_roots.split('\n')[1:] }}"
-
-
-# Create actual publishing environment
-- name: Check for correct esgf-publisher
-  stat:
-    path: "{{ conda.envs }}/esgf-pub/{{ conda.mods }}/esgcet-{{ publisher.pip.version }}.dist-info"
-  register: publisher_module
-
-- name: Cleanup publisher repo
-  when: not publisher_module.stat.exists
-  command: "{{ conda.exe }} env remove -y -n esgf-pub"
-  register: remove_esgfpub
-  failed_when: remove_esgfpub.rc != 0 and "Not a conda environment" not in remove_esgfpub.stderr
-
-- name: Create esgf-pub conda env
-  when: not publisher_module.stat.exists
-  command: "{{ conda.exe }} create -y -n esgf-pub 'python<3'"
-
-- name: Install CMOR into esgf-pub
-  when: not publisher_module.stat.exists
-  command: "{{ conda.exe }} install -y -n esgf-pub 'cmor==3.4.0' -c conda-forge"
-
-- name: Install publisher
-  when: not publisher_module.stat.exists
-  shell: >
-    {{ conda.actv }} esgf-pub && \
-    pip install '{{ publisher.pip.name }}' 'requests==2.20.0'


### PR DESCRIPTION

## Proposed Changes

  - The installer can now be executed as its own phase in the event it is needed to be re-attempted
  - Use a simple environment file for now to manage the conda environment
