### PR TITLE
Add only the host certificate into the truststore

### DIFF
--- a/roles/tomcat/tasks/certs.yml
+++ b/roles/tomcat/tasks/certs.yml
@@ -7,7 +7,7 @@
 
 - name: Import web CA into Truststore
   java_cert:
-    cert_path: "{{ httpd.cachain }}"
+    cert_path: "{{ httpd.hostcert }}"
     keystore_path: "{{ tomcat.ts.path }}"
     keystore_pass: "{{ tomcat.ts.pass }}"
     cert_alias: my_esgf_node


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Do this in an effort to ensure that tomcat can trust itself
