### PR TITLE
Force config clone

### DIFF
--- a/roles/base/tasks/config.yml
+++ b/roles/base/tasks/config.yml
@@ -4,6 +4,7 @@
     repo: "{{ esg.config.repo }}"
     version: "{{ esg.config.version }}"
     dest: /tmp/esgf-config
+    force: yes
 
 - name: Copy ESGF config files into place
   copy:


### PR DESCRIPTION
Fixes #64 

## Proposed Changes

  - Since users should not be modifying `/tmp/esgf-config` it is more reliable to simply force write it if local modifications are present.
