### PR TITLE
Handle legacy naming of base env, 'root', by not specifying a name

### DIFF
--- a/roles/conda/tasks/main.yml
+++ b/roles/conda/tasks/main.yml
@@ -16,4 +16,4 @@
   register: conda_install
 
 - name: Get latest 4.6 Conda
-  command: "{{ conda.exe }} install -y -n base -c defaults 'conda<4.7'"
+  command: "{{ conda.exe }} install -y -c defaults 'conda<4.7'"


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Remove base env specification. The base env used to be the 'root' env prior to conda 4.4. This may be the case for some sites. Either way this command will work if no env is specified, the base or root env will be used.
