### PR TITLE
Disable shard whitelist checks

### DIFF
--- a/roles/start/tasks/main.yml
+++ b/roles/start/tasks/main.yml
@@ -82,7 +82,7 @@
   when: "'index' in group_names"
   become: yes
   become_user: solr
-  command: "{{ solr.path }}/bin/solr start -s {{ solr.home }}/{{ shard.name }}-{{ shard.port }} -p {{ shard.port }} -a {{ shard.args }} -Ddisable.configEdit=true"
+  command: "{{ solr.path }}/bin/solr start -s {{ solr.home }}/{{ shard.name }}-{{ shard.port }} -p {{ shard.port }} -a {{ shard.args }} -Ddisable.configEdit=true -Dsolr.disable.shardsWhitelist=true"
   loop: "{{ existing_shards }}"
   register: result
   changed_when: '"Port {{ shard.port }} is already being used" not in result.stdout'


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-12770  Since any URL can
be specified for the 'shards' parameter Solr developed a whitelist
feature to limit it. Error messages are generated if this cmd line
argument is not specified.