### PR TITLE
udunits2==2.2.27

### DIFF
--- a/roles/publisher/files/environment.yml
+++ b/roles/publisher/files/environment.yml
@@ -72,7 +72,7 @@ dependencies:
   - sqlite=3.27.2
   - tk=8.6.8
   - traitlets=4.3.2
-  - udunits2=2.2.25
+  - udunits2=2.2.27
   - urllib3=1.24.1
   - wheel=0.33.1
   - xz=5.2.4


### PR DESCRIPTION
earlier conda builds of udunits 2.2.5 are lacking an activate script

compare 
* https://anaconda.org/conda-forge/udunits2/2.2.25/download/linux-64/udunits2-2.2.25-1.tar.bz2 (what currently gets installed)
* https://anaconda.org/conda-forge/udunits2/2.2.25/download/linux-64/udunits2-2.2.25-3.tar.bz2 (earliest version with the fix)

The consequence of this is that the necessary environment variable `UDUNITS_XML_PATH` is not set when activating the publisher conda environment.

This pull request *suggests* installing 2.2.27 but would need testing before merging to check whether with this change it will work as a consistent conda environment. I haven't tested this. If not, then a smaller upgrade (e.g. 2.2.26 or a later 2.2.25) may be needed. Check for the presence of `/usr/local/conda/envs/esgf-pub/etc/conda/activate.d/udunits2-activate.sh` (and corresponding deactivate script in `deactivate.d`) after installation.