### PR TITLE
Don't generate redundant self-signed certs for Globus

### DIFF
--- a/group_vars/idp.yml
+++ b/group_vars/idp.yml
@@ -16,7 +16,7 @@ myproxy:
     dir: /var/lib/globus-connect-server/myproxy-ca
     cert: /var/lib/globus-connect-server/myproxy-ca/cacert.pem
     signing_policy: /var/lib/globus-connect-server/myproxy-ca/signing-policy
-    key: /var/lib/globus-connect-server/myproxy-ca/cakey.pem
+    key: /var/lib/globus-connect-server/myproxy-ca/private/cakey.pem
   scripts:
     dir: /esg/config/myproxy
     retriever: /esg/config/myproxy/retriever.py

--- a/group_vars/index.yml
+++ b/group_vars/index.yml
@@ -4,8 +4,8 @@ search_webapp:
   name: esg-search
 
 solr:
-  src: http://archive.apache.org/dist/lucene/solr/6.6.5/solr-6.6.5.zip
-  root_dir: solr-6.6.5
+  src: http://archive.apache.org/dist/lucene/solr/6.6.6/solr-6.6.6.zip
+  root_dir: solr-6.6.6
   path: /usr/local/solr
   home: /usr/local/solr-home
   shards:

--- a/group_vars/index.yml
+++ b/group_vars/index.yml
@@ -4,8 +4,8 @@ search_webapp:
   name: esg-search
 
 solr:
-  src: http://archive.apache.org/dist/lucene/solr/6.6.6/solr-6.6.6.zip
-  root_dir: solr-6.6.6
+  src: http://archive.apache.org/dist/lucene/solr/6.6.5/solr-6.6.5.zip
+  root_dir: solr-6.6.5
   path: /usr/local/solr
   home: /usr/local/solr-home
   shards:

--- a/local_certs.yml
+++ b/local_certs.yml
@@ -18,11 +18,4 @@
     # Install Certs
     - name: Install Globus Identity key/cert
       include_role:
-        name: globus_certs
-
-    # Install GCS config for GridFTP and register
-    - name: Register Globus Connect Server
-      when:
-        - globus_user is defined
-        - globus_pass is defined
-      command: 'globus-connect-server-setup --force'
+        name: globus_tools

--- a/roles/globus_certs/meta/main.yml
+++ b/roles/globus_certs/meta/main.yml
@@ -1,16 +1,5 @@
 
 dependencies:
-  # This is the temporary, ownca-signed, certificate
-  - {
-      role: 'certificate',
-      when: globushostcert is not defined and generate_globus is defined and generate_globus,
-      dest_dir: "{{ grid_security.dir }}",
-      key_dest: "{{ grid_security.host.key }}",
-      csr_dest: "/tmp/globus.csr",
-      cert_dest: "{{ grid_security.host.cert }}",
-      common_name: "{{ hostname.self }}",
-      ownca: true
-    }
   # This is the to be signed CSR and Key generation
   - {
       role: 'certificate',

--- a/roles/globus_tools/tasks/main.yml
+++ b/roles/globus_tools/tasks/main.yml
@@ -10,7 +10,7 @@
 # Get globus tools and libraries
 - name: Import Globus GPG key
   rpm_key:
-    key: http://www.globus.org/ftppub/globus-connect-server/RPM-GPG-KEY-Globus
+    key: https://downloads.globus.org/toolkit/gt6/stable/repo/rpm/RPM-GPG-KEY-Globus
 
 - name: Download globus-connect-server .rpm file
   get_url:

--- a/roles/globus_tools/tasks/main.yml
+++ b/roles/globus_tools/tasks/main.yml
@@ -12,14 +12,9 @@
   rpm_key:
     key: https://downloads.globus.org/toolkit/gt6/stable/repo/rpm/RPM-GPG-KEY-Globus
 
-- name: Download globus-connect-server .rpm file
-  get_url:
-    url: http://toolkit.globus.org/ftppub/globus-connect-server/globus-connect-server-repo-latest.noarch.rpm
-    dest: /tmp/globus-connect-server-repo-latest.noarch.rpm
-
 - name: Install globus-connect-server .rpm file
-  package:
-    name: /tmp/globus-connect-server-repo-latest.noarch.rpm
+  yum:
+    name: https://downloads.globus.org/toolkit/globus-connect-server/globus-connect-server-repo-latest.noarch.rpm
 
 - name: Add ESGF RPM Repo
   template:

--- a/roles/myproxy_certs/meta/main.yml
+++ b/roles/myproxy_certs/meta/main.yml
@@ -1,13 +1,4 @@
 dependencies:
-  # This is the temporary, self-signed, certificate for myproxy
-  - {
-      role: 'certificate',
-      when: myproxycacert is not defined and generate_myproxyca is defined and generate_myproxyca,
-      dest_dir: "{{ myproxy.ca.dir }}",
-      key_dest: "{{ myproxy.ca.key }}",
-      cert_dest: "{{ myproxy.ca.cert }}",
-      use_ownca: true
-    }
   # This is the to be signed CSR and Key generation for myproxy
   - {
       role: 'certificate',

--- a/roles/verify/tasks/main.yml
+++ b/roles/verify/tasks/main.yml
@@ -11,23 +11,23 @@
   fail:
     msg: No web certificate installation method fully specified. See the sample variable file for more information.
 
-# Globus certs check
-- name: Check if globus cert paths are defined
-  set_fact:
-    globuscerts_specified: "{{ (globushostkey is defined and globushostcert is defined)|bool }}"
+# # Globus certs check
+# - name: Check if globus cert paths are defined
+#   set_fact:
+#     globuscerts_specified: "{{ (globushostkey is defined and globushostcert is defined)|bool }}"
 
-- name: Check if globus certificate variables are valid
-  when: not (globuscerts_specified or (generate_globus is defined and generate_globus))
-  fail:
-    msg: No globus certificate installation method fully specified. See the sample variable file for more information.
+# - name: Check if globus certificate variables are valid
+#   when: not (globuscerts_specified or (generate_globus is defined and generate_globus))
+#   fail:
+#     msg: No globus certificate installation method fully specified. See the sample variable file for more information.
 
-# MyProxy certs check
-- name: Check if myproxyca cert paths are defined
-  when: "'idp' in group_names"
-  set_fact:
-    myproxycacerts_specified: "{{ (myproxycakey is defined and myproxycacert is defined and myproxy_signing_policy is defined)|bool }}"
+# # MyProxy certs check
+# - name: Check if myproxyca cert paths are defined
+#   when: "'idp' in group_names"
+#   set_fact:
+#     myproxycacerts_specified: "{{ (myproxycakey is defined and myproxycacert is defined and myproxy_signing_policy is defined)|bool }}"
 
-- name: Check if myproxyca certificate variables are valid
-  when: "'idp' in group_names and not (myproxycacerts_specified or (generate_myproxyca is defined and generate_myproxyca))"
-  fail:
-    msg: No myproxyca certificate installation method fully specified. See the sample variable file for more information.
+# - name: Check if myproxyca certificate variables are valid
+#   when: "'idp' in group_names and not (myproxycacerts_specified or (generate_myproxyca is defined and generate_myproxyca))"
+#   fail:
+#     msg: No myproxyca certificate installation method fully specified. See the sample variable file for more information.

--- a/roles/verify/tasks/main.yml
+++ b/roles/verify/tasks/main.yml
@@ -10,24 +10,3 @@
   when: not (webcerts_specified or (generate_httpd is defined and generate_httpd) or (try_letsencrypt is defined and try_letsencrypt))
   fail:
     msg: No web certificate installation method fully specified. See the sample variable file for more information.
-
-# # Globus certs check
-# - name: Check if globus cert paths are defined
-#   set_fact:
-#     globuscerts_specified: "{{ (globushostkey is defined and globushostcert is defined)|bool }}"
-
-# - name: Check if globus certificate variables are valid
-#   when: not (globuscerts_specified or (generate_globus is defined and generate_globus))
-#   fail:
-#     msg: No globus certificate installation method fully specified. See the sample variable file for more information.
-
-# # MyProxy certs check
-# - name: Check if myproxyca cert paths are defined
-#   when: "'idp' in group_names"
-#   set_fact:
-#     myproxycacerts_specified: "{{ (myproxycakey is defined and myproxycacert is defined and myproxy_signing_policy is defined)|bool }}"
-
-# - name: Check if myproxyca certificate variables are valid
-#   when: "'idp' in group_names and not (myproxycacerts_specified or (generate_myproxyca is defined and generate_myproxyca))"
-#   fail:
-#     msg: No myproxyca certificate installation method fully specified. See the sample variable file for more information.


### PR DESCRIPTION

## Proposed Changes

  - Since Globus generates certificates by default when the GCS is setup it is best to just let this happen rather than generate our own to simply overwrite those generate by Globus.
  - Globus removed the URLs being used for the RPM and RPM Key requiring the use of the new, officially supported URLs