### PR TITLE
Idempotent Solr role

### DIFF
--- a/roles/solr/tasks/add_shard.yml
+++ b/roles/solr/tasks/add_shard.yml
@@ -59,10 +59,15 @@
     owner: solr
     group: solr
 
+- name: Is this Solr instance running
+  shell: "netstat -ln | egrep -q ':{{ shard.port }}' && echo -n running || echo -n stopped"
+  register: is_running
+
 - name: Start this Solr instance
   become: yes
   become_user: solr
   command: "{{ solr.path }}/bin/solr start -s {{ solr.home }}/{{ shard.name }}-{{ shard.port }} -p {{ shard.port }}"
+  when: is_running.stdout == "stopped"
 
 - name: Create cores
   become: yes


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Adds a check to ensure Solr is only started if it is not already running. Avoids port collision error terminating the playbook on a second run.
  -
  -
