### PR TITLE
update environment for psycopg2 v2.7.7 needed for unicode error

### DIFF
--- a/roles/publisher/files/environment.yml
+++ b/roles/publisher/files/environment.yml
@@ -83,7 +83,7 @@ dependencies:
     - cdms2==3.0.0
     - cf-python==2.3.3
     - cftime==1.0.3.4
-    - esgcet==3.7.0
+    - esgcet==3.7.2
     - esgconfigparser==0.1.17
     - esgf-pyclient==0.2.1
     - esgfpid==0.7.12
@@ -101,7 +101,8 @@ dependencies:
     - pbr==5.1.3
     - pika==0.11.2
     - psutil==5.6.1
-    - psycopg2==2.6.2
+    - psycopg2==2.7.7
+    - psycopg2_binary==2.7.4
     - regrid2==3.0.0
     - requests==2.20.0
     - requests-cache==0.4.13


### PR DESCRIPTION
Fixes #

## Proposed Changes

publishing was failing on a datanode (esgf-data1) with psycopg2==2.6.2 due to a Unicode error
Error has not been occurring on other data node (aims3) which has v2.7.7 and psycopg2_binary 
  -
  -
  -
