### PR TITLE
drop accessloggingfilter

### DIFF
--- a/roles/data/templates/thredds/web.xml.j2
+++ b/roles/data/templates/thredds/web.xml.j2
@@ -144,30 +144,6 @@
   <!-- pass through this filter and get logged  -->
   <!-- into the database.                       -->
   <!-- **************************************** -->
-  <filter>
-    <filter-name>AccessLoggingFilter</filter-name>
-    <filter-class>esg.node.filters.AccessLoggingFilter</filter-class>
-    <init-param>
-      <param-name>service.name</param-name>
-      <param-value>thredds</param-value>
-    </init-param>
-    <init-param>
-      <param-name>exempt_extensions</param-name>
-      <param-value>.xml</param-value>
-    </init-param>
-    <init-param>
-      <param-name>exempt_services</param-name>
-      <param-value>thredds/wms, thredds/wcs, thredds/ncss, thredds/ncml, thredds/uddc, thredds/iso, thredds/dodsC</param-value>
-    </init-param>
-    <init-param>
-      <param-name>extensions</param-name>
-      <param-value>.nc</param-value>
-    </init-param>
-  </filter>
-  <filter-mapping>
-    <filter-name>AccessLoggingFilter</filter-name>
-    <url-pattern>/*</url-pattern>
-  </filter-mapping>
   <!--@@esg_node_saml_filter_entry@@-->
 
   <!--@@esg_drs_resolving_filter_entry@@-->


### PR DESCRIPTION
Clearly we don't need to include the access logging filter as it is causing many sites to become unresponsive when faced with many request.