### PR TITLE
IncludeOptional for local httpd include files, and a common include

### DIFF
--- a/roles/httpd/templates/httpd2.2/esgf-httpd.conf.j2
+++ b/roles/httpd/templates/httpd2.2/esgf-httpd.conf.j2
@@ -178,14 +178,14 @@ NameVirtualHost *:80
 
 
 # add local configuration that is to be applied _outside_ of VirtualHost sections, if any,
-# to /etc/httpd/conf/esgf-httpd-local-toplevel.conf
+# to /etc/httpd/conf/esgf-httpd-local-common.conf
 # There are also optional Include files specific to the virtual hosts - see below
 
 # Note: IncludeOptional woks in apache >= 2.3.6.  However, in < 2.4.30, any fixed filename
 #       must still exist or it will fail -- it is only truly optional where a wildcard is used.
 #       So the [f] is a workaround which forces it to be treated as a wildcard.
 
-IncludeOptional /etc/httpd/conf/esgf-httpd-local-toplevel.con[f]
+IncludeOptional /etc/httpd/conf/esgf-httpd-local-common.con[f]
 
 
 <VirtualHost *:80>
@@ -212,7 +212,7 @@ IncludeOptional /etc/httpd/conf/esgf-httpd-local-toplevel.con[f]
 
 	# add local configuration, if any,  to /etc/httpd/conf/esgf-httpd-local.conf (without virtualhost directive).
 	# For https, the file is esgf-httpd-locals.conf (locals for https, local for http)
-	# For outside of VirtualHost sections, there is esgf-httpd-local-toplevel.conf
+	# For outside of VirtualHost sections, there is esgf-httpd-local-common.conf
 	#
 	# (the "[f]" is explained in the above comment re IncludeOptional syntax)
 	IncludeOptional /etc/httpd/conf/esgf-httpd-local.con[f]

--- a/roles/httpd/templates/httpd2.2/esgf-httpd.conf.j2
+++ b/roles/httpd/templates/httpd2.2/esgf-httpd.conf.j2
@@ -175,6 +175,19 @@ NameVirtualHost *:80
         Order deny,allow
         Deny from All
 </Location>
+
+
+# add local configuration that is to be applied _outside_ of VirtualHost sections, if any,
+# to /etc/httpd/conf/esgf-httpd-local-toplevel.conf
+# There are also optional Include files specific to the virtual hosts - see below
+
+# Note: IncludeOptional woks in apache >= 2.3.6.  However, in < 2.4.30, any fixed filename
+#       must still exist or it will fail -- it is only truly optional where a wildcard is used.
+#       So the [f] is a workaround which forces it to be treated as a wildcard.
+
+IncludeOptional /etc/httpd/conf/esgf-httpd-local-toplevel.con[f]
+
+
 <VirtualHost *:80>
 
 	Alias /.well-known/acme-challenge/ /var/www/html/.well-known/acme-challenge/
@@ -197,8 +210,12 @@ NameVirtualHost *:80
 	RewriteCond %{REQUEST_URI} !^/server-status(.*)$
     RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R,L]
 
-	#add local configuration, if any,  to /etc/httpd/conf/esgf-httpd-local.conf (without virtualhost directive) and uncomment following line. For https, the file is esgf-httpd-locals.conf (locals for https, local for http)
-	#Include /etc/httpd/conf/esgf-httpd-local.conf
+	# add local configuration, if any,  to /etc/httpd/conf/esgf-httpd-local.conf (without virtualhost directive).
+	# For https, the file is esgf-httpd-locals.conf (locals for https, local for http)
+	# For outside of VirtualHost sections, there is esgf-httpd-local-toplevel.conf
+	#
+	# (the "[f]" is explained in the above comment re IncludeOptional syntax)
+	IncludeOptional /etc/httpd/conf/esgf-httpd-local.con[f]
 
  	SSLProxyEngine On
 	ProxyPassMatch  ^/solr(.*)$     http://localhost:8983/solr$1

--- a/roles/httpd/templates/httpd2.2/esgf-httpd.ssl.conf.j2
+++ b/roles/httpd/templates/httpd2.2/esgf-httpd.ssl.conf.j2
@@ -28,8 +28,12 @@ NameVirtualHost *:443
 	Header always set Strict-Transport-Security "max-age=31557600; includeSubdomains;"
 	Header always set X-Content-Type-Options nosniff
 
-	#add local configuration, if any,  to /etc/httpd/conf/esgf-httpd-locals.conf (without virtualhost directive) and uncomment following line. For http, the file is esgf-httpd-local.conf (locals for https, local for http)
-	#Include /etc/httpd/conf/esgf-httpd-locals.conf
+	# add local configuration, if any,  to /etc/httpd/conf/esgf-httpd-locals.conf (without virtualhost directive).
+	# For http, the file is esgf-httpd-local.conf (locals for https, local for http)
+	# For outside of VirtualHost sections, there is esgf-httpd-local-toplevel.conf
+	#
+	# (the "[f]" is explained in a comment in esgf-httpd.conf re IncludeOptional syntax)
+	IncludeOptional /etc/httpd/conf/esgf-httpd-locals.con[f]
 
 	ProxyPassMatch  ^/solr(.*)$     http://localhost:8983/solr$1
 	ProxyPassReverse        /solr   http://localhost:8983/solr

--- a/roles/httpd/templates/httpd2.2/esgf-httpd.ssl.conf.j2
+++ b/roles/httpd/templates/httpd2.2/esgf-httpd.ssl.conf.j2
@@ -30,7 +30,7 @@ NameVirtualHost *:443
 
 	# add local configuration, if any,  to /etc/httpd/conf/esgf-httpd-locals.conf (without virtualhost directive).
 	# For http, the file is esgf-httpd-local.conf (locals for https, local for http)
-	# For outside of VirtualHost sections, there is esgf-httpd-local-toplevel.conf
+	# For outside of VirtualHost sections, there is esgf-httpd-local-common.conf
 	#
 	# (the "[f]" is explained in a comment in esgf-httpd.conf re IncludeOptional syntax)
 	IncludeOptional /etc/httpd/conf/esgf-httpd-locals.con[f]


### PR DESCRIPTION
Changes relating to inclusion of httpd local config:

- use of `IncludeOptional` instead of `Include` removes the need to uncomment the `Include` in the main config file when providing a local include file, making management easier if the main config file can be kept unmodified

- adds another optional local include file outside of the VirtualHost sections

(Makes use of wildcard trick used in top answer at https://stackoverflow.com/questions/9690085/how-do-i-include-a-file-in-apache-config-without-generating-an-error-when-it-doe )