### PR TITLE
Update esg search 4.18.1

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -14,7 +14,7 @@ httpd_version: "{{ '2.4' if (is_7) else '2.2' }}"
 versions:
   installer: 4.0.0-alpha1
   java: jdk1.8.0_192
-  search: v4.18.0
+  search: v4.18.1
   stats_api: v1.0.9
   node_manager: v1.0.5
   node_manager_db: 0.1.7

--- a/roles/base/tasks/config.yml
+++ b/roles/base/tasks/config.yml
@@ -17,6 +17,7 @@
     src: /tmp/esgf-config/esgf-prod/{{ item }}.xml
     dest: "{{ esg.config.dir }}/{{ item }}.xml"
     force: no
+    mode: 0644
   loop:
     - esgf_ats_static
     - esgf_cogs
@@ -48,15 +49,18 @@
     src: esgf_idp.xml.j2
     dest: "{{ esg.config.dir }}/esgf_idp.xml"
     force: no
+    mode: 0644
 
 - name: Install esgf_ats.xml
   template:
     src: esgf_ats.xml.j2
     dest: "{{ esg.config.dir }}/esgf_ats.xml"
     force: no
+    mode: 0644
 
 - name: Install esgf_azs.xml
   template:
     src: esgf_azs.xml.j2
     dest: "{{ esg.config.dir }}/esgf_azs.xml"
     force: no
+    mode: 0644

--- a/roles/base/tasks/properties.yml
+++ b/roles/base/tasks/properties.yml
@@ -8,9 +8,11 @@
     src: base.properties.j2
     dest: "{{ esg.config.dir }}/esgf.properties"
     force: no
+    mode: 0644
 
 - name: Install config_type
   template:
     src: config_type.j2
     dest: "{{ esg.config.dir }}/config_type"
     force: no
+    mode: 0644

--- a/roles/conda/tasks/main.yml
+++ b/roles/conda/tasks/main.yml
@@ -8,6 +8,7 @@
   get_url:
     url: https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
     dest: /tmp/Miniconda3-latest-Linux-x86_64.sh
+    mode: 0644
 
 - name: Run miniconda3 installer
   command: "bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -p {{ conda.prefix }}"

--- a/roles/data/tasks/data_usage.yml
+++ b/roles/data/tasks/data_usage.yml
@@ -34,3 +34,4 @@
   copy:
     src: "filebeat/esgf-cas.crt"
     dest: "{{ filebeat.ssl_ca_path }}"
+    mode: 0644

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -16,6 +16,7 @@
   template:
     src: robots.txt
     dest: /var/www/html/robots.txt
+    mode: 0644
 
 # Create config dirs
 - name: Create esgf-proxy configuration directories
@@ -69,6 +70,7 @@
   get_url:
     url: "{{ httpd.trusted_ca.url }}"
     dest: "{{ httpd.cabundle }}"
+    mode: 0644
 
 - name: Copy {{ trusted_certs }} into place
   when: trusted_certs is defined
@@ -122,6 +124,7 @@
     remote_src: yes
     src: "{{ hostkey_src }}"
     dest: "{{ httpd.hostkey }}"
+    mode: 0644
 
 - name: Copy web hostcert into place
   when: hostcert_src is defined
@@ -129,6 +132,7 @@
     remote_src: yes
     src: "{{ hostcert_src }}"
     dest: "{{ httpd.hostcert }}"
+    mode: 0644
 
 - name: Copy web CA chain into place
   when: cachain_src is defined
@@ -142,3 +146,4 @@
   template:
     src: "httpd{{ httpd_version }}/esgf-httpd.ssl.conf.j2"
     dest: /etc/httpd/conf/httpd.ssl.conf
+    mode: 0644

--- a/roles/myproxy_certs/tasks/main.yml
+++ b/roles/myproxy_certs/tasks/main.yml
@@ -78,6 +78,7 @@
     remote_src: yes
     src: "{{ myproxy.ca.cert }}"
     dest: "{{ grid_security.cert_dir }}/{{ myproxyca_hash.stdout.strip() }}.0"
+    mode: "0666"
 
 - name: Install myproxy CA signing policy into {{ grid_security.cert_dir }}
   copy:

--- a/roles/myproxy_certs/tasks/main.yml
+++ b/roles/myproxy_certs/tasks/main.yml
@@ -78,13 +78,14 @@
     remote_src: yes
     src: "{{ myproxy.ca.cert }}"
     dest: "{{ grid_security.cert_dir }}/{{ myproxyca_hash.stdout.strip() }}.0"
-    mode: "0666"
+    mode: 0644
 
 - name: Install myproxy CA signing policy into {{ grid_security.cert_dir }}
   copy:
     remote_src: yes
     src: "{{ myproxy.ca.signing_policy }}"
     dest: "{{ grid_security.cert_dir }}/{{ myproxyca_hash.stdout.strip() }}.signing_policy"
+    mode: 0644
 
 # CentOS7 myproxy-server requires these files be here
 - name: Ensure the myproxy hostcert and hostkey dir exists

--- a/roles/tomcat/tasks/certs.yml
+++ b/roles/tomcat/tasks/certs.yml
@@ -4,6 +4,7 @@
   get_url:
     url: "{{ tomcat.ts.url }}"
     dest: "{{ tomcat.ts.path }}"
+    mode: 0644
 
 - name: Get webcert hash
   command: openssl x509 -in {{ httpd.hostcert }} -hash -noout

--- a/roles/tomcat/tasks/config.yml
+++ b/roles/tomcat/tasks/config.yml
@@ -17,14 +17,17 @@
   template:
     src: setenv.sh.j2
     dest: "{{ tomcat.path }}/bin/setenv.sh"
+    mode: 0644
 
 - name: Install tomcat-users.xml
   template:
     src: tomcat-users.xml.j2
     dest: "{{ esg.config.dir }}/tomcat/tomcat-users.xml"
     force: no
+    mode: 0644
 
 - name: Install context.xml
   copy:
     src: context.xml
     dest: "{{ tomcat.path }}/conf/context.xml"
+    mode: 0644


### PR DESCRIPTION
+ update to pick up esg-search 4.18.1
+ I updated ansible to 2.9.12 on aims1 (jenkins master) where I ran ansible-playbook command to install on esgf-dev2.llnl.gov, and got some warning and this error in /var/log/messages:

FAILURE: /etc/grid-security/certificates/ba60fab8.0 not world readable.  The trustroots directory /etc/grid-security/certificates has failed sanity checks.

This ansible 2.9.12 seems to change the default behavior when installing files to be more restrictive.
This PR specifies the mode when installing files to avoid some of the warnings.

Install completed and services came up -- https://aims1.llnl.gov/jenkins/job/ESGF_Ansible/job/CentOS_7/job/esgf_ansible.esgf-dev2.CentOS7/242/console

b'#1 cog_create_user ... ok'
b'#2 cog_root_login ... ok'
b'#3 cog_user_login ... ok'
b'#4 basic_ping (https://esgf-dev2.llnl.gov/thredds) ... ok'
b'#4 basic_ping (https://esgf-dev2.llnl.gov/esg-orp/home.htm) ... ok'
b'#5 basic_ping (https://esgf-dev2.llnl.gov/esgf-idp) ... ok'
b'#6 basic_ping (https://esgf-dev2.llnl.gov/) ... ok'
b'#6 basic_ping (https://esgf-dev2.llnl.gov/solr/#) ... ok'
b'   basic_ping (https://esgf-dev2.llnl.gov/esg-search/search) ... ok'
b'   basic_ping (https://esgf-dev2.llnl.gov/esg-orp/home.htm) ... ok'
b'#7 slcs_django_admin_login ... ok'


