### PR TITLE
pin sqlparse=0.3.1 for schema_migrate env

### DIFF
--- a/roles/schema_migrate/tasks/main.yml
+++ b/roles/schema_migrate/tasks/main.yml
@@ -6,7 +6,7 @@
   register: schema_download
 
 - name: Create {{ schema_migrate.env }} conda env
-  command: "{{ conda.exe }} create -y -n {{ schema_migrate.env }} 'python<3' pip"
+  command: "{{ conda.exe }} create -y -n {{ schema_migrate.env }} 'python<3' pip 'sqlparse=0.3.1'"
   args:
     creates: "{{ conda.envs }}/{{ schema_migrate.env }}"
 


### PR DESCRIPTION
Fixes #149 

## Proposed Changes

  - pin sqlparse=0.3.1 when creating schema_migrate conda env

Install run:
https://aims1.llnl.gov/jenkins/job/ESGF_Ansible/job/CentOS_7/job/esgf_ansible.esgf-dev2.CentOS7/265/